### PR TITLE
Add LLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ The project consists of three main components:
 
 1. Clone this repository or copy the files to your desired location.
 2. Make sure you have Python 3.6+ installed.
-3. No additional Python packages are required as the implementation uses only standard library modules.
+3. No additional Python packages are required for basic functionality as the implementation uses only standard library modules.
+4. To enable LLM features, install the optional `openai` package:
+
+   ```bash
+   pip install openai
+   ```
 
 ### Fusion 360 Add-in
 
@@ -43,7 +48,9 @@ The project consists of three main components:
 python server.py
 ```
 
-By default, the server will listen on `127.0.0.1:8080`. You can modify the host and port in the code if needed.
+By default, the server will listen on `127.0.0.1:8080`. You can modify the host
+and port in the code if needed. Set the `OPENAI_API_KEY` environment variable if
+you plan to use the LLM integration.
 
 ### Connecting Fusion 360 to the Server
 
@@ -86,6 +93,8 @@ The server and clients communicate using a simple JSON-based protocol over TCP s
 - `get_model_info`: Request information about the current model
 - `command_result`: Response containing the result of a command execution
 - `model_info`: Response containing model information
+- `llm_request`: Request text generation from the configured LLM
+- `llm_result`: Response containing LLM output
 
 ## Extension
 

--- a/client.py
+++ b/client.py
@@ -135,7 +135,17 @@ class MCPClient:
         message = {
             'type': 'get_model_info'
         }
-        
+
+        return self.send_message(message)
+
+    def send_llm_request(self, prompt: str, model: str = 'gpt-3.5-turbo') -> bool:
+        """Send a prompt to the server to be processed by an LLM"""
+        message = {
+            'type': 'llm_request',
+            'prompt': prompt,
+            'model': model
+        }
+
         return self.send_message(message)
 
 
@@ -166,11 +176,14 @@ if __name__ == "__main__":
                 'center': [0, 0, 0],
                 'radius': 10
             })
-            
+
+            # Example: LLM request
+            client.send_llm_request('Summarize the Fusion 360 model')
+
             # Keep the client running for a while to receive responses
             time.sleep(5)
-            
+
         finally:
             client.disconnect()
     else:
-        print("Failed to connect to MCP server. Make sure it's running.") 
+        print("Failed to connect to MCP server. Make sure it's running.")


### PR DESCRIPTION
## Summary
- add optional OpenAI integration in `server.py`
- support new `llm_request` message from the client
- update client example and API to call an LLM
- document OpenAI dependency, API key, and new message types

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68409ce4e95083328706291d08b79822