### PR TITLE
Fix README references and add message framing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The project consists of three main components:
 
 2. **MCP Client** (`client.py`): A Python client library that connects to the MCP server and provides methods for sending commands and receiving responses.
 
-3. **Fusion 360 Add-in** (`fusion360_mcp_addon.py`): A Fusion 360 add-in that connects to the MCP server and provides the actual integration with the Fusion 360 API.
+3. **Fusion 360 Add-in** (`fusion360_mcp_addin.py`): A Fusion 360 add-in that connects to the MCP server and provides the actual integration with the Fusion 360 API.
 
 ## Installation
 
@@ -31,7 +31,7 @@ The project consists of three main components:
 
 ### Fusion 360 Add-in
 
-1. Copy the entire folder containing `fusion360_mcp_addon.py`, `client.py`, `manifest.json` and the `resources` directory to your Fusion 360 **AddIns** directory. Make sure `resources/MCPIcon.png` exists as Fusion 360 requires an icon file.
+1. Copy the entire folder containing `fusion360_mcp_addin.py`, `client.py`, and the `resources` directory to your Fusion 360 **AddIns** directory. Ensure the `resources/MCPIcon` folder contains the required icon files (`32x32-normal.png` and `16x16-normal.png`).
 2. In Fusion 360, open the "Scripts and Add-ins" dialog (press `Shift+S` or find it in the "Design" workspace under "Utilities").
 3. On the "Add-ins" tab choose **Load from my computer** ("Load from Device" on some versions) and select this folder. Selecting the folder starts the add-in.
 4. Click "Run" or enable "Run on Startup" to have it automatically load when Fusion 360 starts.
@@ -107,7 +107,7 @@ You can extend the server and add-in to support additional functionality:
 
 ## License
 
-This project is provided as-is without any warranty. Use at your own risk.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
 
 ## Contributing
 

--- a/resources/placeholder.txt
+++ b/resources/placeholder.txt
@@ -1,4 +1,5 @@
 This is a placeholder file for the resources directory.
 You should replace this with actual icon files for the Fusion 360 add-in.
 
-For the MCP icon, create a 32x32 PNG file named "MCPIcon.png" in this directory. 
+Place the MCP icons in the `MCPIcon` subdirectory. Include at least
+`32x32-normal.png` and `16x16-normal.png` for the add-in to load correctly.


### PR DESCRIPTION
## Summary
- fix README references and install instructions
- clarify placeholder icon text
- add MIT license
- implement newline-delimited JSON protocol in server and client

## Testing
- `python -m py_compile server.py client.py fusion360_mcp_addin.py`

------
https://chatgpt.com/codex/tasks/task_e_684a1ab459f48332ba7f0bd2d8b04059